### PR TITLE
Allow defining a vDS when adding an SR-IOV device

### DIFF
--- a/vhpc_toolkit/get_args.py
+++ b/vhpc_toolkit/get_args.py
@@ -536,6 +536,13 @@ def get_args():
         help="Name of port group which could enable SR-IOV adapter type",
     )
     sriov_parser.add_argument(
+        "--dvs_name",
+        action="store",
+        type=str,
+        help="Name of distributed virtual switch which could enable SR-IOV",
+    )
+
+    sriov_parser.add_argument(
         "--pf",
         action="store",
         type=str,

--- a/vhpc_toolkit/operations.py
+++ b/vhpc_toolkit/operations.py
@@ -1255,11 +1255,15 @@ class Operations(object):
         """
 
         tasks = []
+        dvs_obj = []
         vm_obj = self.objs.get_vm(vm_cfg["vm"])
         host_obj = self.objs.get_host_by_vm(vm_obj)
         vm_update = ConfigVM(vm_obj)
         Check().check_kv(vm_cfg, "pf", required=True)
         Check().check_kv(vm_cfg, "sriov_port_group", required=True)
+        if (Check().check_kv(vm_cfg, "dvs_name")) :
+            dvs_name = vm_cfg["dvs_name"]
+            dvs_obj = self.objs.get_dvs(dvs_name)
         pf = vm_cfg["pf"]
         pf_obj = GetHost(host_obj).pci_obj(pf)
         pg = vm_cfg["sriov_port_group"]
@@ -1271,7 +1275,7 @@ class Operations(object):
                 "Find physical function {0} for VM {1} "
                 "and this physical function is SR-IOV capable".format(pf, vm_obj.name)
             )
-            tasks.append(vm_update.add_sriov_adapter(pg_obj, pf_obj))
+            tasks.append(vm_update.add_sriov_adapter(pg_obj, pf_obj, dvs_obj))
         else:
             self.logger.error(
                 "This physical function is not SR-IOV capable. " "Skipping"


### PR DESCRIPTION
This is a quick and dirty implementation of allowing vDS configuration.
I'm not super familiar with python, pyvmomi, nor this codebase, so there may be some stuff missing. 
(Removing those vDS interfaces for example).
Feel free to toss it out if you have a better way to implement this.